### PR TITLE
Wait for previous executions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,8 @@ resource "aws_lambda_function" "receiver" {
       SLACK_WEBHOOK_URL            = jsonencode(var.slack_webhook_url)
     }
   }
-  tags = var.tags
+  timeout = var.lambda_timeout
+  tags    = var.tags
 }
 
 resource "aws_lambda_function" "dispatcher" {
@@ -47,7 +48,8 @@ resource "aws_lambda_function" "dispatcher" {
       SLACK_WEBHOOK_URL = var.slack_webhook_url
     }
   }
-  tags = var.tags
+  timeout = var.lambda_timeout
+  tags    = var.tags
 }
 
 resource "aws_iam_role" "dispatcher" {

--- a/main.tf
+++ b/main.tf
@@ -27,8 +27,8 @@ resource "aws_lambda_function" "receiver" {
   source_code_hash = filebase64sha256(data.archive_file.receiver.output_path)
   environment {
     variables = {
-      WAIT_FOR_PREVIOUS_EXECUTIONS = var.wait_for_previous_executions
-      SLACK_WEBHOOK_URL            = jsonencode(var.slack_webhook_url)
+      SLACK_WEBHOOK_URL            = var.slack_webhook_url
+      WAIT_FOR_PREVIOUS_EXECUTIONS = jsonencode(var.wait_for_previous_executions)
     }
   }
   timeout = var.lambda_timeout

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,8 @@ resource "aws_lambda_function" "receiver" {
   source_code_hash = filebase64sha256(data.archive_file.receiver.output_path)
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      WAIT_FOR_PREVIOUS_EXECUTIONS = var.wait_for_previous_executions
+      SLACK_WEBHOOK_URL            = jsonencode(var.slack_webhook_url)
     }
   }
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -72,8 +72,8 @@ resource "aws_iam_role_policy" "logs_to_receiver" {
   role   = aws_iam_role.receiver.id
 }
 
-resource "aws_iam_role_policy" "task_status_to_receiver" {
-  policy = data.aws_iam_policy_document.task_status_for_lambda.json
+resource "aws_iam_role_policy" "sfn_to_receiver" {
+  policy = data.aws_iam_policy_document.sfn_for_lambda.json
   role   = aws_iam_role.receiver.id
 }
 

--- a/policies.tf
+++ b/policies.tf
@@ -28,10 +28,11 @@ data "aws_iam_policy_document" "logs_for_lambda" {
   }
 }
 
-data "aws_iam_policy_document" "task_status_for_lambda" {
+data "aws_iam_policy_document" "sfn_for_lambda" {
   statement {
     effect = "Allow"
     actions = [
+      "states:ListExecutions",
       "states:SendTaskSuccess",
       "states:SendTaskFailure"
     ]

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -53,7 +53,7 @@ def lambda_handler(event, context):
         if wait_for_previous_executions:
             executions = client.list_executions(
                 stateMachineArn=state_machine_arn, maxResults=500
-            )
+            )["executions"]
             current_execution = next(
                 (
                     execution

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,11 @@ variable "state_machine_arns" {
   type        = list(string)
 }
 
+variable "wait_for_previous_executions" {
+  description = "Whether to allow for task approval/rejection if there are previous executions still running."
+  default     = true
+}
+
 variable "slack_webhook_url" {
   description = "The URL of a Slack webhook to post messages to."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -23,3 +23,8 @@ variable "slack_webhook_url" {
   description = "The URL of a Slack webhook to post messages to."
   type        = string
 }
+
+variable "lambda_timeout" {
+  description = "The maximum number of seconds the Lambda functions are allowed to run."
+  default     = 30
+}


### PR DESCRIPTION
Add functionality for optionally enforcing that previously unfinished executions must have finished before approving the current execution.